### PR TITLE
Listing: Fix typo in IoTerop name.

### DIFF
--- a/content/en/listing.md
+++ b/content/en/listing.md
@@ -543,7 +543,7 @@ Below you can read more about each company's product and how it's utilizing LwM2
 </table>
 
 
-## IoTErop
+## IoTerop
 
 <table>
   <thead>


### PR DESCRIPTION
Signed-off-by: David Navarro <david.navarro@ioterop.com>